### PR TITLE
Remove unused tracee externed variable from pipe.c

### DIFF
--- a/pipe.c
+++ b/pipe.c
@@ -20,7 +20,6 @@
 #define BYTECODE_BUF_SZ 64000000 // 64mb
 
 extern struct options_t options;
-extern pid_t tracee;
 
 static const
 int _is_ascii(


### PR DESCRIPTION
The `extern pid_t tracee;` present in pipe.c is unused and not really imported from anywhere.