### PR TITLE
Apply gcc -Wpedantic linting

### DIFF
--- a/arch/amd64/include/arch.h
+++ b/arch/amd64/include/arch.h
@@ -17,8 +17,8 @@ struct user_fpregs_struct_amd64
 	unsigned short int    swd;
 	unsigned short int    ftw;
 	unsigned short int    fop;
-	unsigned long long int rip;
-	unsigned long long int rdp;
+	unsigned long int rip;
+	unsigned long int rdp;
 	unsigned int      mxcsr;
 	unsigned int      mxcr_mask;
 	unsigned int      st_space[32];   /* 8*16 bytes for each FP-reg = 128 bytes */
@@ -28,33 +28,33 @@ struct user_fpregs_struct_amd64
 
 struct user_regs_struct_amd64
 {
-	unsigned long long int r15;
-	unsigned long long int r14;
-	unsigned long long int r13;
-	unsigned long long int r12;
-	unsigned long long int rbp;
-	unsigned long long int rbx;
-	unsigned long long int r11;
-	unsigned long long int r10;
-	unsigned long long int r9;
-	unsigned long long int r8;
-	unsigned long long int rax;
-	unsigned long long int rcx;
-	unsigned long long int rdx;
-	unsigned long long int rsi;
-	unsigned long long int rdi;
-	unsigned long long int orig_rax;
-	unsigned long long int rip;
-	unsigned long long int cs;
-	unsigned long long int eflags;
-	unsigned long long int rsp;
-	unsigned long long int ss;
-	unsigned long long int fs_base;
-	unsigned long long int gs_base;
-	unsigned long long int ds;
-	unsigned long long int es;
-	unsigned long long int fs;
-	unsigned long long int gs;
+	unsigned long int r15;
+	unsigned long int r14;
+	unsigned long int r13;
+	unsigned long int r12;
+	unsigned long int rbp;
+	unsigned long int rbx;
+	unsigned long int r11;
+	unsigned long int r10;
+	unsigned long int r9;
+	unsigned long int r8;
+	unsigned long int rax;
+	unsigned long int rcx;
+	unsigned long int rdx;
+	unsigned long int rsi;
+	unsigned long int rdi;
+	unsigned long int orig_rax;
+	unsigned long int rip;
+	unsigned long int rsp;
+	unsigned int eflags;
+	unsigned int ss;
+	unsigned int fs_base;
+	unsigned int gs_base;
+	unsigned int cs;
+	unsigned int ds;
+	unsigned int es;
+	unsigned int fs;
+	unsigned int gs;
 };
 
 struct proc_info_t {

--- a/arch/amd64/ptrace_amd64.c
+++ b/arch/amd64/ptrace_amd64.c
@@ -26,7 +26,7 @@ void ptrace_reset_amd64(
 		const pid_t child_pid,
 		const unsigned long start)
 {
-	struct user_regs_struct_amd64 regs_struct = {};
+	struct user_regs_struct_amd64 regs_struct = {0};
 	struct iovec regs = {.iov_base = &regs_struct, .iov_len = sizeof(regs_struct) };
 
 	REQUIRE (ptrace(PTRACE_GETREGSET, child_pid, NT_PRSTATUS, &regs) == 0);

--- a/common.c
+++ b/common.c
@@ -124,7 +124,7 @@ void verbose_dump(
 void dump(
 		const uint8_t *const buf,
 		const size_t sz,
-		const unsigned long long base)
+		const unsigned long base)
 {
 	for (size_t i = 0; i < sz; i += 0x10) {
 		if (base != -1) printf(REGFMT ": ", base + i);

--- a/exedir.c
+++ b/exedir.c
@@ -37,12 +37,16 @@ static
 void _clean_rappel_dir(void)
 {
 	char path[PATH_MAX] = { 0 };
-	snprintf(path, sizeof(path), "%s/exe", options.rappel_dir);
+	int ret = snprintf(path, sizeof(path), "%s/exe", options.rappel_dir);
+	if (ret < 0) {
+		fprintf(stderr, "Path excedes max path length: %s/exe", options.rappel_dir);
+		exit(EXIT_FAILURE);
+	}
 
 	DIR *exedir = opendir(path);
 
 	REQUIRE (exedir != NULL);
-	
+
 	struct dirent *f;
 	while ((f = readdir(exedir))) {
 		if (!strcmp(f->d_name, ".") || !strcmp(f->d_name, ".."))
@@ -50,8 +54,12 @@ void _clean_rappel_dir(void)
 
 		if (!strcmp(f->d_name, "history"))
 			continue;
-		
-		snprintf(path, sizeof(path), "%s/exe/%s", options.rappel_dir, f->d_name);
+
+		ret = snprintf(path, sizeof(path), "%s/exe/%s", options.rappel_dir, f->d_name);
+		if (ret < 0) {
+			fprintf(stderr, "Path excedes max path length: %s/exe/%s", options.rappel_dir, f->d_name);
+			exit(EXIT_FAILURE);
+		}
 
 		if (unlink(path) == -1)
 			fprintf(stderr, "Cannot unlink %s: %s\n", f->d_name, strerror(errno));
@@ -81,7 +89,11 @@ void init_rappel_dir(void)
 		REQUIRE (errno == EEXIST);
 
 	char path[PATH_MAX] = { 0 };
-	snprintf(path, sizeof path, "%s/%s", options.rappel_dir, "exe");
+	int ret = snprintf(path, sizeof path, "%s/exe", options.rappel_dir);
+	if (ret < 0) {
+		fprintf(stderr, "Path excedes max path length: %s/exe", options.rappel_dir);
+		exit(EXIT_FAILURE);
+	}
 
 	if (mkdir(path, 0755) == -1)
 		REQUIRE (errno == EEXIST);
@@ -107,7 +119,7 @@ int write_named_file(
 		const size_t data_sz,
 		const char *name)
 {
-	const int h = open(name, O_WRONLY | O_CREAT, 
+	const int h = open(name, O_WRONLY | O_CREAT,
 			S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
 
 	REQUIRE (h >= 0);
@@ -124,7 +136,11 @@ int write_tmp_file(
 {
 	char path[PATH_MAX] = { 0 };
 
-	snprintf(path, sizeof(path), "%s/exe/rappel-exe.XXXXXX", options.rappel_dir);
+	int ret = snprintf(path, sizeof(path), "%s/exe/rappel-exe.XXXXXX", options.rappel_dir);
+	if (ret < 0) {
+		fprintf(stderr, "Path excedes max path length: %s/exe/rappel-exe.XXXXXX", options.rappel_dir);
+		exit(EXIT_FAILURE);
+	}
 
 	const int h = mkstemp(path);
 

--- a/include/common.h
+++ b/include/common.h
@@ -66,4 +66,4 @@ void verbose_dump(
 void dump(
 		const uint8_t *const,
 		const size_t,
-		const unsigned long long);
+		const unsigned long);

--- a/pipe.c
+++ b/pipe.c
@@ -53,7 +53,7 @@ size_t _read_bytecode(
 	const size_t raw_sz = read_data(STDIN_FILENO, raw, STDIN_BUF_SZ);
 
 
-	// If we've read in 64mb of data, we're just going to assume there's more 
+	// If we've read in 64mb of data, we're just going to assume there's more
 	// we're not reading
 	if (raw_sz >= STDIN_BUF_SZ) {
 		fprintf(stderr, "Too much bytecode to handle, exiting...\n");
@@ -66,7 +66,7 @@ size_t _read_bytecode(
 			exit(EXIT_FAILURE);
 		} else {
 			memcpy(data, raw, raw_sz);
-			
+
 			free(raw);
 
 			return raw_sz;
@@ -75,7 +75,7 @@ size_t _read_bytecode(
 		_semi_to_linebreak((char *)raw, raw_sz);
 
 		const size_t asm_sz = assemble(data, data_sz, (char *)raw, raw_sz);
-	
+
 		free(raw);
 
 		return asm_sz;
@@ -122,7 +122,7 @@ void pipe_mode(void)
 		close(exe_fd);
 		ptrace_launch(tracee);
 
-		struct proc_info_t info = {};
+		struct proc_info_t info = {0};
 		ARCH_INIT_PROC_INFO(info);
 
 		ptrace_cont(tracee, &info);

--- a/ui.c
+++ b/ui.c
@@ -151,7 +151,11 @@ void interact(
 	history(hist, &ev, H_SETSIZE, 100);
 
 	char hist_path[PATH_MAX] = { 0 };
-	snprintf(hist_path, sizeof hist_path, "%s/history", options.rappel_dir);
+	int ret = snprintf(hist_path, sizeof hist_path, "%s/history", options.rappel_dir);
+	if (ret < 0) {
+		fprintf(stderr, "Path excedes max path length: %s/history", options.rappel_dir);
+		exit(EXIT_FAILURE);
+	}
 
 	history(hist, &ev, H_LOAD, hist_path);
 
@@ -167,7 +171,7 @@ void interact(
 	size_t buf_sz = 0;
 	int end = 0, child_died = 0;
 
-	struct proc_info_t info = {};
+	struct proc_info_t info = {0};
 	ARCH_INIT_PROC_INFO(info);
 
 	ptrace_launch(child_pid);


### PR DESCRIPTION
I know you mention using clang to compile the project, but this PR will allow for compilation with gcc7 without any warnings.

Also, removed some extra whitespace.

Note: I only tested the AMD64 version. (i couldn't get arm or x86 to work, even on master)

<details> <summary> Output before changes </summary>

```
[nix-shell:/home/jon/projects/rappel]$ CC=gcc make > make.output.txt
exedir.c: In function ‘init_rappel_dir’:
exedir.c:84:34: warning: ‘%s’ directive output may be truncated writing 3 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
  snprintf(path, sizeof path, "%s/%s", options.rappel_dir, "exe");
                                  ^~                       ~~~~~
In file included from /nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/stdio.h:862:0,
                 from exedir.c:7:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 5 and 4100 bytes into a destination of size 4096
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
exedir.c:40:34: warning: ‘/exe’ directive output may be truncated writing 4 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]
  snprintf(path, sizeof(path), "%s/exe", options.rappel_dir);
                                  ^~~~
In file included from /nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/stdio.h:862:0,
                 from exedir.c:7:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 5 and 4100 bytes into a destination of size 4096
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
exedir.c:54:35: warning: ‘/exe/’ directive output may be truncated writing 5 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]
   snprintf(path, sizeof(path), "%s/exe/%s", options.rappel_dir, f->d_name);
                                   ^~~~~
In file included from /nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/stdio.h:862:0,
                 from exedir.c:7:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 6 and 4356 bytes into a destination of size 4096
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
exedir.c: In function ‘write_tmp_file’:
exedir.c:127:34: warning: ‘/exe/rappel-exe.XXXXXX’ directive output may be truncated writing 22 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]
  snprintf(path, sizeof(path), "%s/exe/rappel-exe.XXXXXX", options.rappel_dir);
                                  ^~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/stdio.h:862:0,
                 from exedir.c:7:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 23 and 4118 bytes into a destination of size 4096
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
exedir.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-gnu-empty-initializer’
In file included from common.c:8:0:
common.c: In function ‘dump’:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
<command-line>:0:8: note: in expansion of macro ‘REGFMT64’
common.c:130:26: note: in expansion of macro ‘REGFMT’
   if (base != -1) printf(REGFMT ": ", base + i);
                          ^~~~~~
In file included from include/common.h:6:0,
                 from common.c:8:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
common.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-gnu-empty-initializer’
ui.c: In function ‘interact’:
ui.c:170:28: warning: ISO C forbids empty initializer braces [-Wpedantic]
  struct proc_info_t info = {};
                            ^
ui.c:154:43: warning: ‘/history’ directive output may be truncated writing 8 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]
  snprintf(hist_path, sizeof hist_path, "%s/history", options.rappel_dir);
                                           ^~~~~~~~
In file included from /nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/stdio.h:862:0,
                 from /nix/store/1xis4m31zjwy2zyass4sb8y5vmax4a4p-libedit-20190324-3.1-dev/include/histedit.h:47,
                 from ui.c:10:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 9 and 4104 bytes into a destination of size 4096
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ui.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-gnu-empty-initializer’
pipe.c: In function ‘pipe_mode’:
pipe.c:125:29: warning: ISO C forbids empty initializer braces [-Wpedantic]
   struct proc_info_t info = {};
                             ^
pipe.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-gnu-empty-initializer’
arch/amd64/ptrace_amd64.c: In function ‘ptrace_reset_amd64’:
arch/amd64/ptrace_amd64.c:29:46: warning: ISO C forbids empty initializer braces [-Wpedantic]
  struct user_regs_struct_amd64 regs_struct = {};
                                              ^
arch/amd64/ptrace_amd64.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-gnu-empty-initializer’
In file included from arch/amd64/display_amd64.c:3:0:
arch/amd64/display_amd64.c: In function ‘display_amd64’:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:22:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rax=", rax, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:22:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rax=", rax, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:23:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rbx=", rbx, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:23:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rbx=", rbx, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:24:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rcx=", rcx, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:24:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rcx=", rcx, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:26:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rdx=", rdx, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:26:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rdx=", rdx, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:27:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rsi=", rsi, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:27:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rsi=", rsi, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:28:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rdi=", rdi, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:28:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rdi=", rdi, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:30:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rip=", rip, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:30:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rip=", rip, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:31:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rsp=", rsp, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:31:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rsp=", rsp, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:32:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rbp=", rbp, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:32:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("rbp=", rbp, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:34:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64(" r8=", r8 , regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:34:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64(" r8=", r8 , regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:35:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64(" r9=", r9 , regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:35:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64(" r9=", r9 , regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:36:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r10=", r10, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:36:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r10=", r10, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:38:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r11=", r11, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:38:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r11=", r11, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:39:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r12=", r12, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:39:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r12=", r12, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:40:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r13=", r13, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:40:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r13=", r13, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:42:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r14=", r14, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:42:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r14=", r14, regs, old_regs, " ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:43:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r15=", r15, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:43:2: note: in expansion of macro ‘PRINTREG64’
  PRINTREG64("r15=", r15, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:29:18: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT16 "%04"  PRIx16
                  ^
include/printfmt.h:41:10: note: in expansion of macro ‘REGFMT16’
   printf(REGFMT16, y->x); \
          ^~~~~~~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:76:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("cs=", cs, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:43:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT16 RST, y->x); \
          ^~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:76:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("cs=", cs, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:29:18: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT16 "%04"  PRIx16
                  ^
include/printfmt.h:41:10: note: in expansion of macro ‘REGFMT16’
   printf(REGFMT16, y->x); \
          ^~~~~~~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:77:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("ss=", ss, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:43:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT16 RST, y->x); \
          ^~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:77:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("ss=", ss, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:29:18: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT16 "%04"  PRIx16
                  ^
include/printfmt.h:41:10: note: in expansion of macro ‘REGFMT16’
   printf(REGFMT16, y->x); \
          ^~~~~~~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:78:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("ds=", ds, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:43:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT16 RST, y->x); \
          ^~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:78:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("ds=", ds, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:29:18: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT16 "%04"  PRIx16
                  ^
include/printfmt.h:41:10: note: in expansion of macro ‘REGFMT16’
   printf(REGFMT16, y->x); \
          ^~~~~~~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:80:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("es=", es, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:43:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT16 RST, y->x); \
          ^~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:80:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("es=", es, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:29:18: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT16 "%04"  PRIx16
                  ^
include/printfmt.h:41:10: note: in expansion of macro ‘REGFMT16’
   printf(REGFMT16, y->x); \
          ^~~~~~~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:81:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("fs=", fs, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:43:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT16 RST, y->x); \
          ^~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:81:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("fs=", fs, regs, old_regs, "  ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:29:18: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT16 "%04"  PRIx16
                  ^
include/printfmt.h:41:10: note: in expansion of macro ‘REGFMT16’
   printf(REGFMT16, y->x); \
          ^~~~~~~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:82:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("gs=", gs, regs, old_regs, "            ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:43:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT16 RST, y->x); \
          ^~~
include/printfmt.h:49:3: note: in expansion of macro ‘DUMPREG16’
   DUMPREG16(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:82:2: note: in expansion of macro ‘PRINTREG16’
  PRINTREG16("gs=", gs, regs, old_regs, "            ");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:119:19: note: format string is defined here
 # define PRIx16  "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:28:18: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT32 "%08"  PRIx32
                  ^
include/printfmt.h:26:10: note: in expansion of macro ‘REGFMT32’
   printf(REGFMT32, y->x); \
          ^~~~~~~~
include/printfmt.h:34:3: note: in expansion of macro ‘DUMPREG32’
   DUMPREG32(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:83:2: note: in expansion of macro ‘PRINTREG32’
  PRINTREG32("efl=", eflags, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:120:19: note: format string is defined here
 # define PRIx32  "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:28:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT32 RST, y->x); \
          ^~~
include/printfmt.h:34:3: note: in expansion of macro ‘DUMPREG32’
   DUMPREG32(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:83:2: note: in expansion of macro ‘PRINTREG32’
  PRINTREG32("efl=", eflags, regs, old_regs, "\n");
  ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:120:19: note: format string is defined here
 # define PRIx32  "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:87:3: note: in expansion of macro ‘PRINTREG64’
   PRINTREG64("rip: ", rip, fpregs, old_fpregs, "\t");
   ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:87:3: note: in expansion of macro ‘PRINTREG64’
   PRINTREG64("rip: ", rip, fpregs, old_fpregs, "\t");
   ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:3:0:
include/common.h:27:18: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define REGFMT64 "%016" PRIx64
                  ^
include/printfmt.h:11:10: note: in expansion of macro ‘REGFMT64’
   printf(REGFMT64, y->x); \
          ^~~~~~~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:88:3: note: in expansion of macro ‘PRINTREG64’
   PRINTREG64("rdp: ", rdp, fpregs, old_fpregs, "\t");
   ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
In file included from arch/amd64/display_amd64.c:7:0:
include/printfmt.h:5:13: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Wformat=]
 #define RED "\x1b[0;31m"
             ^
include/printfmt.h:13:10: note: in expansion of macro ‘RED’
   printf(RED REGFMT64 RST, y->x); \
          ^~~
include/printfmt.h:19:3: note: in expansion of macro ‘DUMPREG64’
   DUMPREG64(x, y, z); \
   ^~~~~~~~~
arch/amd64/display_amd64.c:88:3: note: in expansion of macro ‘PRINTREG64’
   PRINTREG64("rdp: ", rdp, fpregs, old_fpregs, "\t");
   ^~~~~~~~~~
In file included from include/common.h:6:0,
                 from arch/amd64/display_amd64.c:3:
/nix/store/bniand9afisrgrsfi7kr093334iv3ibv-glibc-2.27-dev/include/inttypes.h:121:34: note: format string is defined here
 # define PRIx64  __PRI64_PREFIX "x"
arch/amd64/display_amd64.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-gnu-empty-initializer’
```
</details>

<details> <summary> Output after changes </summary>

```
[nix-shell:/home/jon/projects/rappel]$ CC=gcc make
mkdir -p obj
mkdir -p obj/arch/amd64
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c rappel.c  -o obj/rappel.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c exedir.c  -o obj/exedir.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c common.c  -o obj/common.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c ptrace.c  -o obj/ptrace.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c ui.c  -o obj/ui.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c pipe.c  -o obj/pipe.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c arch/amd64/assemble_intel.c  -o obj/arch/amd64/assemble_intel.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c arch/amd64/ptrace_amd64.c  -o obj/arch/amd64/ptrace_amd64.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c arch/amd64/dump_amd64.c  -o obj/arch/amd64/dump_amd64.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c arch/amd64/elf_amd64.c  -o obj/arch/amd64/elf_amd64.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -Iinclude/ -Iarch/amd64/include -c arch/amd64/display_amd64.c  -o obj/arch/amd64/display_amd64.o
gcc -std=c11 -Wall -pedantic -Ddisplay=display_amd64 -Dgen_elf=gen_elf_amd64 -Dptrace_reset=ptrace_reset_amd64 -Ddump_state=dump_state_amd64 -Dptrace_reset=ptrace_reset_amd64 -Dptrace_collect_regs=ptrace_collect_regs_amd64 -Dassemble=assemble_intel -DREGFMT=REGFMT64 -DARCH_INIT_PROC_INFO=AMD64_INIT_PROC_INFO -O2 -fPIE -D_FORTIFY_SOURCE=2 -o bin/rappel  obj/rappel.o  obj/exedir.o  obj/common.o  obj/ptrace.o  obj/ui.o  obj/pipe.o  obj/arch/amd64/assemble_intel.o  obj/arch/amd64/ptrace_amd64.o  obj/arch/amd64/dump_amd64.o  obj/arch/amd64/elf_amd64.o  obj/arch/amd64/display_amd64.o  -ledit
Done.
```
</details>