### PR TITLE
Initialize buf, properly log invalid assembly, fix some typos

### DIFF
--- a/ui.c
+++ b/ui.c
@@ -317,6 +317,8 @@ void interact(
 
 		// Since we fell through, we want to avoid adding .end to our buffer
 		if (!end) {
+			if (!buf_sz)
+				memset(buf, 0, sizeof(buf));
 			memcpy(buf + buf_sz, line, count);
 			buf_sz += count;
 		}
@@ -327,11 +329,12 @@ void interact(
 			uint8_t bytecode[PAGE_SIZE];
 			const size_t bytecode_sz = assemble(bytecode, sizeof(bytecode), buf, buf_sz);
 
-			memset(buf, 0, sizeof(buf));
+			if (buf_sz && buf[buf_sz - 1] == '\n') // kill last newline
+				buf[buf_sz - 1] = 0;
 			buf_sz = 0;
-			end    = 0;
+			end = 0;
 
-			verbose_printf("Got asm(%zu):\n", bytecode_sz);
+			verbose_printf("Got asm (%zu):\n", bytecode_sz);
 			verbose_dump(bytecode, bytecode_sz, -1);
 
 			if (!bytecode_sz) {

--- a/ui.c
+++ b/ui.c
@@ -262,7 +262,7 @@ void interact(
 		// count is 0 == ^d
 		if (!count || strcasestr(line, ".quit") || strcasestr(line, ".exit")) break;
 
-		// We have input, add it to the our history
+		// We have input, add it to our history
 		history(hist, &ev, H_ENTER, line);
 
 		// If we start with a ., we have a command
@@ -315,7 +315,7 @@ void interact(
 			continue;
 		}
 
-		// Since we fell through, we want to avoid adding adding .end to our buffer
+		// Since we fell through, we want to avoid adding .end to our buffer
 		if (!end) {
 			memcpy(buf + buf_sz, line, count);
 			buf_sz += count;


### PR DESCRIPTION
This fixes two issues as illustrated below. First, 'buf' is not initialized,
thus strings might not be zero-terminated (notice 'QV' random characters
below). Second, invalid instructions are not logged since 'buf' is cleared
beforehand (notice '' below).
    
    Trying to assemble (4):
    nop
    QVnasm is pid 10515
    Got asm(1):
    90
    
    Trying to assemble (5):
    crap
    nasm is pid 10533
    /dev/fd/3:3: warning: label alone on a line without a colon might be in error [>
    Got asm(0):
    '' assembled to 0 length bytecode