### PR TITLE
Write data files to XDG_DATA_HOME if it exists

### DIFF
--- a/exedir.c
+++ b/exedir.c
@@ -15,7 +15,7 @@
 #include "common.h"
 #include "exedir.h"
 
-#define RAPPEL_DIR ".rappel"
+#define RAPPEL_DIR "rappel"
 
 extern struct options_t options;
 
@@ -71,19 +71,30 @@ void _clean_rappel_dir(void)
 void init_rappel_dir(void)
 {
 	const char *home = getenv("HOME");
+	const char *xdg_data_home = getenv("XDG_DATA_HOME");
 
 	if (!home) {
 		fprintf(stderr, "HOME not set");
 		exit(EXIT_FAILURE);
 	}
 
-	snprintf(
-		options.rappel_dir,
-		sizeof(options.rappel_dir),
-		"%s/%s",
-		home,
-		RAPPEL_DIR
-	);
+	if (!xdg_data_home) {
+		snprintf(
+			options.rappel_dir,
+			sizeof(options.rappel_dir),
+			"%s/.%s",
+			home,
+			RAPPEL_DIR
+		);
+	} else {
+		snprintf(
+			options.rappel_dir,
+			sizeof(options.rappel_dir),
+			"%s/%s",
+			xdg_data_home,
+			RAPPEL_DIR
+		);
+	}
 
 	if (mkdir(options.rappel_dir, 0755) == -1)
 		REQUIRE (errno == EEXIST);


### PR DESCRIPTION
Fallback to HOME, if XDG_DATA_HOME does not exist.
The XDG Base Directory Specification is a widely used specification which specifies where files should be located depending on their usage published by the freedesktop.org-organization.

ref: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html